### PR TITLE
Ssr take 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"babel-loader": "^8.2.5",
 				"css-loader": "^6.7.1",
 				"esbuild": "^0.14.43",
+				"html-webpack-harddisk-plugin": "^2.0.0",
 				"html-webpack-plugin": "^5.5.0",
 				"postcss": "^8.4.13",
 				"postcss-loader": "^6.2.1",
@@ -5630,6 +5631,19 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/html-webpack-harddisk-plugin": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-2.0.0.tgz",
+			"integrity": "sha512-fWKH72FyaQ5K/j+kYy6LnQsQucSDnsEkghmB6g29TtpJ4sxHYFduEeUV1hfDqyDpCRW+bP7yacjQ+1ikeIDqeg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13"
+			},
+			"peerDependencies": {
+				"html-webpack-plugin": "^5.0.0",
+				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/html-webpack-plugin": {
@@ -15461,6 +15475,13 @@
 				"relateurl": "^0.2.7",
 				"terser": "^5.10.0"
 			}
+		},
+		"html-webpack-harddisk-plugin": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-2.0.0.tgz",
+			"integrity": "sha512-fWKH72FyaQ5K/j+kYy6LnQsQucSDnsEkghmB6g29TtpJ4sxHYFduEeUV1hfDqyDpCRW+bP7yacjQ+1ikeIDqeg==",
+			"dev": true,
+			"requires": {}
 		},
 		"html-webpack-plugin": {
 			"version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"babel-loader": "^8.2.5",
 		"css-loader": "^6.7.1",
 		"esbuild": "^0.14.43",
+		"html-webpack-harddisk-plugin": "^2.0.0",
 		"html-webpack-plugin": "^5.5.0",
 		"postcss": "^8.4.13",
 		"postcss-loader": "^6.2.1",

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,9 +2,9 @@ module Main where
 
 import Prelude
 
-import Deku.Toplevel (runInBody)
+import Deku.Toplevel (hydrate)
 import Effect (Effect)
 import Parser.Main as Parser
 
 main :: Effect Unit
-main = runInBody Parser.main
+main = hydrate Parser.main

--- a/src/Parser/Main.purs
+++ b/src/Parser/Main.purs
@@ -23,7 +23,6 @@ import Data.FunctorWithIndex (mapWithIndex)
 import Data.Generic.Rep (class Generic)
 import Data.Int (floor)
 import Data.List (List)
-import Data.List as List
 import Data.Map (Map, SemigroupMap(..))
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromJust, fromMaybe)

--- a/src/Parser/Main.purs
+++ b/src/Parser/Main.purs
@@ -1023,6 +1023,7 @@ main =
               [ D.div_ [ stateComponent addEvent ]
               , D.button (bang (D.OnClick := addNew "x") <|> buttonClass) [ text_ "Add" ]
               ]
+        , D.div_ [D.div_ [D.div_ [D.div_ [D.div_ [D.div_ [text_ "foobar"]]]]]]
         , D.div_
             [ event.errorMessage # switcher \et -> case et of
                 Nothing -> envy empty

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,20 +2,22 @@ const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const HtmlWebpackHarddiskPlugin = require("html-webpack-harddisk-plugin");
 const webpack = require("webpack");
-const ssr = require("./ssr");
+const { spawn } = require("node:child_process");
+let ssr;
 // A JavaScript class.
 class DekuSSRPlugin {
   apply(compiler) {
     // Specify the event hook to attach to
     compiler.hooks.beforeCompile.tapAsync(
 			"DekuSSRPlugin",
-			(compilation, callback) => {
-				console.log("This is an example plugin!");
-				console.log(
-					"Here’s the `compilation` object which represents a single build of assets:",
-					compilation
-				);
-				callback();
+			(_, callback) => {
+				const makeSSR = spawn("esbuild", ["./output/SSR/index.js", "--bundle", "--format=cjs", "--outfile=ssr.js"]);
+
+				makeSSR.on("close", (code) => {
+					ssr = require("./ssr");
+					console.log(`SSR processed with code: ${code}`);
+					callback();
+				});
 			}
 		);
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
-//const ssr = require("./ssr");
+const ssr = require("./ssr");
 module.exports = {
 	mode: "development",
 	entry: "./src/index.js",
@@ -11,15 +11,7 @@ module.exports = {
 	},
 	plugins: [
 		new HtmlWebpackPlugin({
-			templateContent: `<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width">
-		<title>PureScript Blog</title>
-	</head>
-  <body></body>
-</html>`, //ssr.ssr(),
+			templateContent: ssr.ssr(),
 		}),
 		new webpack.EnvironmentPlugin({
 			LIL_GUI: "true",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,23 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const HtmlWebpackHarddiskPlugin = require("html-webpack-harddisk-plugin");
 const webpack = require("webpack");
 const ssr = require("./ssr");
+// A JavaScript class.
+class DekuSSRPlugin {
+  apply(compiler) {
+    // Specify the event hook to attach to
+    compiler.hooks.beforeCompile.tapAsync(
+			"DekuSSRPlugin",
+			(compilation, callback) => {
+				console.log("This is an example plugin!");
+				console.log(
+					"Here’s the `compilation` object which represents a single build of assets:",
+					compilation
+				);
+				callback();
+			}
+		);
+  }
+}
 module.exports = {
 	mode: "development",
 	entry: "./src/index.js",
@@ -11,9 +28,10 @@ module.exports = {
 		filename: "bundle.js",
 	},
 	plugins: [
+		new DekuSSRPlugin(),
 		new HtmlWebpackPlugin({
 			alwaysWriteToDisk: true,
-			templateContent: ssr.ssr,
+			templateContent: () => {console.log('template content created'); return ssr.ssr() },
 		}),
 		new HtmlWebpackHarddiskPlugin(),
 		new webpack.EnvironmentPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const HtmlWebpackHarddiskPlugin = require("html-webpack-harddisk-plugin");
 const webpack = require("webpack");
 const ssr = require("./ssr");
 module.exports = {
@@ -11,8 +12,10 @@ module.exports = {
 	},
 	plugins: [
 		new HtmlWebpackPlugin({
-			templateContent: ssr.ssr(),
+			alwaysWriteToDisk: true,
+			templateContent: ssr.ssr,
 		}),
+		new HtmlWebpackHarddiskPlugin(),
 		new webpack.EnvironmentPlugin({
 			LIL_GUI: "true",
 		}),


### PR DESCRIPTION
The tricky thing with SSR is that we'll need an additional webpack hook that recompiles SSR.purs every time a dependency changes. Otherwise, even though it writes the page's HTML anew every time there's a page load, it'll grab it from the original un-updated SSR.